### PR TITLE
Fix compatibility with HTseq-count v0.8

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -347,10 +347,10 @@ DESeqDataSetFromMatrix <- function( countData, colData, design, tidy=FALSE, igno
 DESeqDataSetFromHTSeqCount <- function( sampleTable, directory=".", design, ignoreRank=FALSE, ...) 
 {
   if (missing(design)) stop("design is missing")
-  l <- lapply( as.character( sampleTable[,2] ), function(fn) read.table( file.path( directory, fn ) ) )
+  l <- lapply( as.character( sampleTable[,2] ), function(fn) read.table( file.path( directory, fn ),fill=TRUE ) )
   if( ! all( sapply( l, function(a) all( a$V1 == l[[1]]$V1 ) ) ) )
     stop( "Gene IDs (first column) differ between files." )
-  tbl <- sapply( l, function(a) a$V2 )
+  tbl <- sapply( l, function(a) a[,ncol(a)] )
   colnames(tbl) <- sampleTable[,1]
   rownames(tbl) <- l[[1]]$V1
   rownames(sampleTable) <- sampleTable[,1]


### PR DESCRIPTION
With HTseq-count version> 0.8, option --additional-attr allows to add a column in the output files (e.g., with readable gene names instead of IDs), which makes DESeqDataSetFromHTSeqCount crash because column V2 is not the one with the counts, which is the last column instead.