### PR TITLE
Single cell performance improvement part 2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Title: Differential gene expression analysis based on the negative
 Version: 1.25.8
 Authors@R: c(
     person("Michael", "Love", email="michaelisaiahlove@gmail.com", role = c("aut","cre")),
-    person("Constantine", "Ahlmann-Eltze", role = c("ctb")),
+    person("Constantin", "Ahlmann-Eltze", role = c("ctb")),
     person("Simon", "Anders", role = c("aut","ctb")),
     person("Wolfgang", "Huber", role = c("aut","ctb")))
 Maintainer: Michael Love <michaelisaiahlove@gmail.com>

--- a/src/DESeq2.cpp
+++ b/src/DESeq2.cpp
@@ -256,7 +256,7 @@ List fitBeta(SEXP ySEXP, SEXP xSEXP, SEXP nfSEXP, SEXP alpha_hatSEXP, SEXP contr
   arma::mat beta_var_mat = arma::zeros(beta_mat.n_rows, beta_mat.n_cols);
   arma::mat contrast_num = arma::zeros(beta_mat.n_rows, 1);
   arma::mat contrast_denom = arma::zeros(beta_mat.n_rows, 1);
-  arma::mat hat_matrix = arma::zeros(x.n_rows, x.n_rows);
+  arma::vec hat_matrix_diag = arma::zeros(x.n_rows);
   arma::mat hat_diagonals = arma::zeros(y.n_rows, y.n_cols);
   arma::colvec lambda = as<arma::colvec>(lambdaSEXP);
   arma::colvec contrast = as<arma::colvec>(contrastSEXP);
@@ -398,8 +398,19 @@ List fitBeta(SEXP ySEXP, SEXP xSEXP, SEXP nfSEXP, SEXP alpha_hatSEXP, SEXP contr
       w_vec = mu_hat/(1.0 + alpha_hat(i) * mu_hat);
       w_sqrt_vec = sqrt(w_vec);
     }
-    hat_matrix = (x.each_col() % w_sqrt_vec) * (x.t() * (x.each_col() % w_vec) + ridge).i() * (x.each_col() % w_sqrt_vec).t() ;
-    hat_diagonals.row(i) = diagvec(hat_matrix).t();
+    arma::mat xw = x.each_col() % w_sqrt_vec;
+    arma::mat xtwxr_inv = (x.t() * (x.each_col() % w_vec) + ridge).i();
+    
+    // Verbose, but fast way to get diagonal of:
+    // hat_matrix = xw * xtwxr_inv * xw.t() ;
+    for(int jp = 0; jp < y_m; jp++){
+      for(int idx1 = 0; idx1 < x_p; idx1++){
+        for(int idx2 = 0; idx2 < x_p; idx2++){
+          hat_matrix_diag(jp) += xw(jp, idx1) * (xw(jp, idx2) * xtwxr_inv(idx2, idx1));     
+        }
+      }
+    }
+    hat_diagonals.row(i) = hat_matrix_diag.t();
     // sigma is the covariance matrix for the betas
     sigma = (x.t() * (x.each_col() % w_vec) + ridge).i() * x.t() * (x.each_col() % w_vec) * (x.t() * (x.each_col() % w_vec) + ridge).i();
     contrast_num.row(i) = contrast.t() * beta_hat;

--- a/src/DESeq2.cpp
+++ b/src/DESeq2.cpp
@@ -256,7 +256,6 @@ List fitBeta(SEXP ySEXP, SEXP xSEXP, SEXP nfSEXP, SEXP alpha_hatSEXP, SEXP contr
   arma::mat beta_var_mat = arma::zeros(beta_mat.n_rows, beta_mat.n_cols);
   arma::mat contrast_num = arma::zeros(beta_mat.n_rows, 1);
   arma::mat contrast_denom = arma::zeros(beta_mat.n_rows, 1);
-  arma::vec hat_matrix_diag = arma::zeros(x.n_rows);
   arma::mat hat_diagonals = arma::zeros(y.n_rows, y.n_cols);
   arma::colvec lambda = as<arma::colvec>(lambdaSEXP);
   arma::colvec contrast = as<arma::colvec>(contrastSEXP);
@@ -398,6 +397,7 @@ List fitBeta(SEXP ySEXP, SEXP xSEXP, SEXP nfSEXP, SEXP alpha_hatSEXP, SEXP contr
       w_vec = mu_hat/(1.0 + alpha_hat(i) * mu_hat);
       w_sqrt_vec = sqrt(w_vec);
     }
+    arma::vec hat_matrix_diag = arma::zeros(x.n_rows);
     arma::mat xw = x.each_col() % w_sqrt_vec;
     arma::mat xtwxr_inv = (x.t() * (x.each_col() % w_vec) + ridge).i();
     

--- a/vignettes/DESeq2.Rmd
+++ b/vignettes/DESeq2.Rmd
@@ -108,7 +108,7 @@ just reply that the question should be posted to the
 
 ## Acknowledgments
 
-Constantine Ahlmann-Eltze has contributed core code for increasing the
+Constantin Ahlmann-Eltze has contributed core code for increasing the
 computational performance of *DESeq2*.
 
 We have benefited in the development of *DESeq2* from the help and


### PR DESCRIPTION
Hi Mike,

there was another bottleneck in the `fitBeta()` method that made the runtime scale quadratically with the number of samples. Previously, the full hat_matrix was calculated although only the diagonal was needed. I replaced the offending line with a for loop (I couldn't come up with a more elegant linear algebra formulation). It doesn't add as much performance gain as the first PR, but it should still be noticeable if there are very many samples.

Best, Constantin