### PR TITLE
Make algorithm in nOrMoreInCell more efficient

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -2155,14 +2155,9 @@ recordMaxCooks <- function(design, colData, modelMatrix, cooks, numRow) {
 # so for a 2 x 3 comparison, the returned vector for n = 3 is:
 # FALSE, FALSE, TRUE, TRUE, TRUE
 nOrMoreInCell <- function(modelMatrix, n){
-  numEqual <- rep(NA, nrow(modelMatrix))
-  for(idx in seq_len(nrow(modelMatrix))){
-    if(is.na(numEqual[idx])){
-      modelMatrixDiff <- t(t(modelMatrix) - modelMatrix[idx,])
-      equal_to_idx <- apply(modelMatrixDiff, 1, function(row) all(row == 0))
-      numEqual[equal_to_idx] <- sum(equal_to_idx)
-    }
-  }
+  row_hash <- apply(modelMatrix, 1, paste0, collapse = "_")
+  hash_table <- table(row_hash)
+  numEqual <- as.vector(unname(hash_table[row_hash]))
   numEqual >= n
 }
 


### PR DESCRIPTION
The old algorithm was efficient if there were only categorical values
but scaled quadratically if the rows were all different. For example
when there is a continuous variable. The new algorithm is a bit of a
hack because I would prefer to calculate a hash for each row, but the
paste0(..., collapse) works similar and is only slight less memory
efficient. However, the new algorithm doesn't have any of the scaling
problems (as far as I can tell)