### PR TITLE
Fix Problems with glmGamPoi Integration

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -777,19 +777,13 @@ estimateDispersionsGeneEst <- function(object, minDisp=1e-8, kappa_0=1,
     https://doi.org/10.1101/2020.08.13.249623")
       Counts <- counts(objectNZ)
       initial_lp <- vapply(which(fitidx), function(idx){
-        # glmGamPoi:::conventional_loglikelihood_fast(Counts[idx, ], mu = fitMu[idx, ],
-        #   log_theta = log(alpha_hat)[idx], model_matrix = modelMatrix,
-        #   do_cr_adj = TRUE)
         sum(dnbinom(Counts[idx, ], mu = fitMu[idx, ], size = 1 / alpha_hat[idx], log = TRUE))
       }, FUN.VALUE = 0.0)
       dispersion_fits <- glmGamPoi::overdispersion_mle(Counts[fitidx, ], mean = fitMu[fitidx, ],
                                                        model_matrix = modelMatrix, verbose = ! quiet)
       dispIter[fitidx] <- dispersion_fits$iterations
-      alpha_hat_new[fitidx] <- pmin(dispersion_fits$estimates, maxDisp)
+      alpha_hat_new[fitidx] <- pmin(dispersion_fits$estimate, maxDisp)
       last_lp <- vapply(which(fitidx), function(idx){
-        # glmGamPoi:::conventional_loglikelihood_fast(Counts[idx, ], mu = fitMu[idx, ],
-        #   log_theta = log(alpha_hat_new)[idx], model_matrix = modelMatrix,
-        #   do_cr_adj = TRUE)
         sum(dnbinom(Counts[idx, ], mu = fitMu[idx, ], size = 1 / alpha_hat_new[idx], log = TRUE))
       }, FUN.VALUE = 0.0)
     }

--- a/R/core.R
+++ b/R/core.R
@@ -879,8 +879,8 @@ estimateDispersionsFit <- function(object,fitType=c("parametric","local","mean",
       stop("type='glmGamPoi' requires installing the Bioconductor package 'glmGamPoi'")
     }
     base_means <- mcols(objectNZ)$baseMean[useForFit]
-    median_fit <- glmGamPoi:::loc_median_fit(base_means,
-                                             mcols(objectNZ)$dispGeneEst[useForFit])    
+    median_fit <- glmGamPoi::loc_median_fit(base_means, 
+                                            mcols(objectNZ)$dispGeneEst[useForFit])
     get_closest_index <- function(x, vec){
       iv <- findInterval(x, vec)
       dist_left <- x - vec[ifelse(iv == 0, NA, iv)]


### PR DESCRIPTION
Hi Mike,

I have now exported `loc_median_fit()` from glmGamPoi and call it with the `::` notation.
I have also fixed an issue, because I renamed one of the returned objects from `estimate` to `estimates` in glmGamPoi (sorry about that).

The R CMD check should now run without problems.

In https://github.com/mikelove/DESeq2/commit/d3c1075a84800a64284585c790e9ed1e04d4abac, you added a switch for the `minmu` argument of the `DESeq()` function. Does it make sense to add a similar switch to `nbinomLRT()` and `estimateDispersionsGeneEst()`?


Best,
Constantin
