### PR TITLE
fix DESeqDataSetFromHTSeqCount bug when using tibble or data.table

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -385,6 +385,7 @@ DESeqDataSetFromMatrix <- function( countData, colData, design, tidy=FALSE, igno
 #' @export
 DESeqDataSetFromHTSeqCount <- function( sampleTable, directory=".", design, ignoreRank=FALSE, ...) 
 {
+  sampleTable <- as.data.frame(sampleTable) # in case tibble or data.table are provided
   if (missing(design)) stop("design is missing")
   l <- lapply( as.character( sampleTable[,2] ), function(fn) read.table( file.path( directory, fn ), fill=TRUE ) )
   if( ! all( sapply( l, function(a) all( a$V1 == l[[1]]$V1 ) ) ) )


### PR DESCRIPTION
When using either a `tibble` or `data.table` as input to `sampleTable` the function errors, because the single-column subset on those objects returns an object of the same class rather than a vector. 

My proposed change is to simply coerce `sampleTable` to a `data.frame` and leave the rest of the code unchanged. An alternative would have been to use list `[[` subset for the columns. However, assigning rownames to `tibble` objects is not advised (and throws a message) and therefore seems to be less future-proof. 