### PR TITLE
Small fix for "lfcShrink" with "apeglm" estimator

### DIFF
--- a/R/lfcShrink.R
+++ b/R/lfcShrink.R
@@ -335,7 +335,7 @@ Reference: https://doi.org/10.1093/bioinformatics/bty895")
     stopifnot(!missing(coef))
     # if we are using adaptive prior, get the LFC columns
     if (apeAdapt) {
-      incomingCoef <- gsub(" ","_",sub("log2 fold change \\(MLE\\): ","",mcols(res)[2,2]))
+      incomingCoef <- gsub(" ","_",sub("log2 fold change \\(MLE\\): ","",mcols(res)$description[2]))
       if (coefAlpha != incomingCoef) {
         stop("'coef' should specify same coefficient as in results 'res'")
       }


### PR DESCRIPTION
This change makes `lfcShrink(..., type="apeglm")` slightly more robust by using the column name ("description") of the results metadata table, rather than the column number, to extract the coefficient to shrink.

In an analysis I ended up with an additional column named "labelDescription" as the first metadata column of the results table, which meant that "description" was in column 3, not 2. This led to the confusing error message: `'coef' should specify same coefficient as in results 'res'`, although `coef` was set correctly (and `res` was generated by `lfcShrink`, not passed in).

I assume the "labelDescription" column was somehow added because I converted an `ExpressionSet` (generated by function `processNanostringData` from package "NanoTube") to a `RangedSummarizedExperiment` using `makeSummarizedExperimentFromExpressionSet` as input for DESeq2.