### PR TITLE
Fix bug on estimateDispersionsGeneEst when niter is larger than 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: DESeq2
 Type: Package
 Title: Differential gene expression analysis based on the negative
     binomial distribution
-Version: 1.39.5
+Version: 1.39.6
 Authors@R: c(
     person("Michael", "Love", email="michaelisaiahlove@gmail.com", role = c("aut","cre")),
     person("Constantin", "Ahlmann-Eltze", role = c("ctb")),

--- a/R/core.R
+++ b/R/core.R
@@ -793,17 +793,18 @@ estimateDispersionsGeneEst <- function(object, minDisp=1e-8, kappa_0=1,
     https://doi.org/10.1093/bioinformatics/btaa1009")
       Counts <- counts(objectNZ)
       initial_lp <- vapply(which(fitidx), function(idx){
-        sum(dnbinom(Counts[idx, ], mu = fitMu[idx, ], size = 1 / alpha_hat[idx], log = TRUE))
+        sum(dnbinom(Counts[idx, ], mu = fitMu, size = 1 / alpha_hat[idx], log = TRUE))
       }, FUN.VALUE = 0.0)
-      dispersion_fits <- glmGamPoi::overdispersion_mle(Counts[fitidx, ], mean = fitMu[fitidx, ],
+      dispersion_fits <- glmGamPoi::overdispersion_mle(Counts[fitidx, ], mean = fitMu,
                                                        model_matrix = modelMatrix, verbose = ! quiet)
       dispIter[fitidx] <- dispersion_fits$iterations
       alpha_hat_new[fitidx] <- pmin(dispersion_fits$estimate, maxDisp)
       last_lp <- vapply(which(fitidx), function(idx){
-        sum(dnbinom(Counts[idx, ], mu = fitMu[idx, ], size = 1 / alpha_hat_new[idx], log = TRUE))
+        sum(dnbinom(Counts[idx, ], mu = fitMu, size = 1 / alpha_hat_new[idx], log = TRUE))
       }, FUN.VALUE = 0.0)
     }
     fitidx <- abs(log(alpha_hat_new) - log(alpha_hat)) > .05
+    fitidx[is.na(fitidx)] <- FALSE
     alpha_hat <- alpha_hat_new
     if (sum(fitidx) == 0) break
   }


### PR DESCRIPTION
I think I found a minor bug in estimateDispersionsGeneEst when the parameter niter is set to > 1 and `fitType="glmGamPoi"`. 

- The indexing `fitMu[idx, ]` inside the `else if (type == "glmGamPoi")` chunk was not necessary as `fitMu` already has the correct dimensions specified in the line that generates it  (i.e. `fit <- fitNbinomGLMs(objectNZ[fitidx,,drop=FALSE], ...`).
- Also within the interactions across `niter`, when `alpha_hat `and `alpha_hat_new` had both zero values, it returned NA values. This seemed to happen when one of the groups has all zero counts and glmGamPoi is used.

Hope I'm not chasing my own tail here. 

Here is the code that generated the error message:


```
data("pasillaDEXSeqDataSet", package="pasilla")
dxd <- estimateSizeFactors( dxd )
modelMatrix <- DEXSeq:::rmDepCols( model.matrix(design(dxd), as.data.frame(colData(dxd))))
tst <- estimateDispersionsGeneEst( dxd, quiet=FALSE, modelMatrix = modelMatrix, niter = 10, type="glmGamPoi" )

using 'glmGamPoi' as fitType. If used in published research, please cite:
    Ahlmann-Eltze, C., Huber, W. (2020) glmGamPoi: Fitting Gamma-Poisson
    Generalized Linear Models on Single Cell Count Data. Bioinformatics.
    https://doi.org/10.1093/bioinformatics/btaa1009
using 'glmGamPoi' as fitType. If used in published research, please cite:
    Ahlmann-Eltze, C., Huber, W. (2020) glmGamPoi: Fitting Gamma-Poisson
    Generalized Linear Models on Single Cell Count Data. Bioinformatics.
    https://doi.org/10.1093/bioinformatics/btaa1009
Error in fitMu[idx, ] : subscript out of bounds

```
 