### PR TITLE
Optimize dispersion estimation in estimateDispersionsGeneEst

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -794,21 +794,22 @@ estimateDispersionsGeneEst <- function(object, minDisp=1e-8, kappa_0=1,
     Ahlmann-Eltze, C., Huber, W. (2020) glmGamPoi: Fitting Gamma-Poisson
     Generalized Linear Models on Single Cell Count Data. Bioinformatics.
     https://doi.org/10.1093/bioinformatics/btaa1009")
+      Counts <- counts(objectNZ)[fitidx,,drop=FALSE]
       initial_lp <- vapply(seq_len(nrow(fitMu)), function(idx) {
-        sum(dnbinom(x = counts(objectNZ)[fitidx,][idx,],
+        sum(dnbinom(x = Counts[idx,],
                     mu = fitMu[idx,],
                     size = 1 / alpha_hat[fitidx][idx],
                     log = TRUE))
       }, FUN.VALUE = 0.0)
       dispersion_fits <- glmGamPoi::overdispersion_mle(
-                                      counts(objectNZ)[fitidx,], mean = fitMu,
+                                      Counts, mean = fitMu,
                                       model_matrix = modelMatrix, verbose = ! quiet
                                     )
       dispIter[fitidx] <- dispersion_fits$iterations
       alpha_hat_new[fitidx] <- pmin(dispersion_fits$estimate, maxDisp)
       last_lp <- vapply(seq_len(nrow(fitMu)), function(idx) {
-        sum(dnbinom(x = counts(objectNZ)[fitidx,][idx,],
-                    mu = fitMu[idx,]
+        sum(dnbinom(x = Counts[idx,],
+                    mu = fitMu[idx,],
                     size = 1 / alpha_hat_new[fitidx][idx],
                     log = TRUE))
       }, FUN.VALUE = 0.0)


### PR DESCRIPTION
Re. PR #64 and our discussion on https://github.com/thelovelab/DESeq2/pull/64#issuecomment-1976167484, I make some adjustments to speed up the process. 

In short, I created the subsetted count matrix `Counts` as in previous version, so that the same subsetting is not performed again and again in the two `vapply` loops to slow things down.

`Counts <- counts(objectNZ)[fitidx,,drop=FALSE]`

Before _optimization_

```r
> system.time({
        dds <- estimateDispersionsGeneEst(dds, type = "glmGamPoi")
})
# using 'glmGamPoi' as fitType. If used in published research, please cite:
#     Ahlmann-Eltze, C., Huber, W. (2020) glmGamPoi: Fitting Gamma-Poisson
#     Generalized Linear Models on Single Cell Count Data. Bioinformatics.
#     https://doi.org/10.1093/bioinformatics/btaa1009
#    user  system elapsed 
# 196.027   3.311 195.619 
```
After _optimization_

```r
> system.time({
        dds <- estimateDispersionsGeneEst(dds, type = "glmGamPoi")
})
# using 'glmGamPoi' as fitType. If used in published research, please cite:
#     Ahlmann-Eltze, C., Huber, W. (2020) glmGamPoi: Fitting Gamma-Poisson
#     Generalized Linear Models on Single Cell Count Data. Bioinformatics.
#     https://doi.org/10.1093/bioinformatics/btaa1009
#    user  system elapsed 
#  11.352   2.980  10.645 
```