### PR TITLE
Remove some instances of partial matching

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -1179,7 +1179,7 @@ estimateDispersionsPriorVar <- function(object, minDisp=1e-8, modelMatrix=NULL) 
       kl
     })
     lofit <- loess(klDivs ~ obsVarGrid, span=.2)
-    obsVarFineGrid <- seq(from=0,to=8,length=1000)
+    obsVarFineGrid <- seq(from=0,to=8,length.out=1000)
     lofitFitted <- predict(lofit,obsVarFineGrid)
     argminKL <- obsVarFineGrid[which.min(lofitFitted)]
     expVarLogDisp <- trigamma((m - p)/2)

--- a/R/fitNbinomGLMs.R
+++ b/R/fitNbinomGLMs.R
@@ -260,7 +260,7 @@ fitGLMsWithPrior <- function(object, betaTol, maxit, useOptim, useQR, betaPriorV
                          minmu=minmu)
     modelMatrix <- fit$modelMatrix
     modelMatrixNames <- colnames(modelMatrix)
-    H <- fit$hat_diagonal
+    H <- fit$hat_diagonals
     betaMatrix <- fit$betaMatrix
     mu <- fit$mu
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -197,7 +197,7 @@ collapseReplicates <- function(object, groupby, run, renameCols=TRUE) {
   }
   groupby <- droplevels(groupby)
   stopifnot(length(groupby) == ncol(object))
-  sp <- split(seq(along=groupby), groupby)
+  sp <- split(seq_along(groupby), groupby)
   countdata <- sapply(sp, function(i) MatrixGenerics::rowSums(assay(object)[,i,drop=FALSE]))
   mode(countdata) <- "integer"
   colsToKeep <- sapply(sp, `[`, 1)

--- a/R/results.R
+++ b/R/results.R
@@ -676,7 +676,7 @@ pvalueAdjustment <- function(res, independentFiltering, filter,
     if (missing(theta)) {
       lowerQuantile <- mean(filter == 0)
       if (lowerQuantile < .95) upperQuantile <- .95 else upperQuantile <- 1
-      theta <- seq(lowerQuantile, upperQuantile, length=50)
+      theta <- seq(lowerQuantile, upperQuantile, length.out=50)
     }
 
     # do filtering using genefilter

--- a/R/vst.R
+++ b/R/vst.R
@@ -246,7 +246,7 @@ vst <- function(object, blind=TRUE, nsub=1000, fitType="parametric") {
   object.sub <- object[baseMean > 5,]
   baseMean <- baseMean[baseMean > 5]
   o <- order(baseMean)
-  idx <- o[round(seq(from=1, to=length(o), length=nsub))]
+  idx <- o[round(seq(from=1, to=length(o), length.out=nsub))]
   object.sub <- object.sub[idx,]
 
   # estimate dispersion trend

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -69,7 +69,7 @@ fitDispGridWrapper <- function(y, x, mu, logAlphaPriorMean, logAlphaPriorSigmaSq
                                paste(arg.names[na.test],collapse=", ")))
   minLogAlpha <- log(1e-8)
   maxLogAlpha <- log(max(10, ncol(y)))
-  dispGrid <- seq(from=minLogAlpha, to=maxLogAlpha, length=20)
+  dispGrid <- seq(from=minLogAlpha, to=maxLogAlpha, length.out=20)
   logAlpha <- fitDispGrid(ySEXP=y, xSEXP=x, mu_hatSEXP=mu, disp_gridSEXP=dispGrid,
                           log_alpha_prior_meanSEXP=logAlphaPriorMean,
                           log_alpha_prior_sigmasqSEXP=logAlphaPriorSigmaSq,

--- a/tests/testthat/test_dispersions.R
+++ b/tests/testthat/test_dispersions.R
@@ -129,7 +129,7 @@ test_that("the fitting of dispersion gives expected values using various methods
   dds <- estimateSizeFactors(dds)
   dds <- estimateDispersionsGeneEst(dds, niter=5)
   with(mcols(dds)[!mcols(dds)$allZero,],
-       expect_equal(log(trueDisp), log(dispGeneEst),tol=0.2))
+       expect_equal(log(trueDisp), log(dispGeneEst),tolerance=0.2))
 
 })
 

--- a/tests/testthat/test_outlier.R
+++ b/tests/testthat/test_outlier.R
@@ -30,7 +30,7 @@ test_that("outlier filtering and replacement works as expected", {
   expect_equal(results(dds1)$pvalue[idx], results(dds0)$pvalue[idx])
 
   # check that outlier filtering catches throughout range of mu
-  beta0 <- seq(from=1,to=16,length=100)
+  beta0 <- seq(from=1,to=16,length.out=100)
   idx <- rep(rep(c(TRUE,FALSE),c(1,9)),10)
   set.seed(1)
   #par(mfrow=c(2,3))

--- a/tests/testthat/test_parallel.R
+++ b/tests/testthat/test_parallel.R
@@ -6,7 +6,7 @@ test_that("parallel execution works as expected", {
   counts(dds0)[51:60,] <- 0L
 
   nworkers <- 4
-  idx <- factor(sort(rep(seq_len(nworkers),length=nrow(dds0))))
+  idx <- factor(sort(rep(seq_len(nworkers),length.out=nrow(dds0))))
 
   dds <- estimateSizeFactors(dds0)
   dds <- do.call(rbind, lapply(levels(idx), function(l) {

--- a/tests/testthat/test_results.R
+++ b/tests/testthat/test_results.R
@@ -4,7 +4,7 @@ test_that("results works as expected and throws errors", {
   set.seed(1)
   dds <- makeExampleDESeqDataSet(n=200,m=12)
   dds$condition <- factor(rep(1:3,each=4))
-  dds$group <- factor(rep(1:2,length=ncol(dds)))
+  dds$group <- factor(rep(1:2,length.out=ncol(dds)))
   dds$foo <- rep(c("lo","hi"),each=6)
   counts(dds)[1,] <- rep(c(100L,200L,800L),each=4)
 
@@ -73,7 +73,7 @@ test_that("results: designs with zero intercept", {
   set.seed(1)
   dds <- makeExampleDESeqDataSet(n=100,m=12)
   dds$condition <- factor(rep(1:3,each=4))
-  dds$group <- factor(rep(1:2,length=ncol(dds)))
+  dds$group <- factor(rep(1:2,length.out=ncol(dds)))
 
   counts(dds)[1,] <- rep(c(100L,200L,400L),each=4)
 


### PR DESCRIPTION
This is mostly innocuous, but I noticed this while trying to remove partial matching from my own code.

One could say that:

- it's slightly better for future-proofing your code as it ensures future similarly named arguments would make your code that until now relied on partial matching trip.
- not relying on partial matching makes the work of static analysis tools more reliable

Feel free to close this PR if you believe this is not improving anything though.